### PR TITLE
Fix OpenIdUserValidator validation of user from Google

### DIFF
--- a/src/main/groovy/io/github/joxebus/micronaut/security/OpenIdUserValidator.groovy
+++ b/src/main/groovy/io/github/joxebus/micronaut/security/OpenIdUserValidator.groovy
@@ -40,8 +40,8 @@ class OpenIdUserValidator implements OpenIdClaimsValidator {
             Role userRole = roleService.findByName(RoleEnum.USER.toString())
             user = new User()
             user.with {
-                username:email
-                password:UUID.randomUUID().toString()
+                username = email
+                password = UUID.randomUUID().toString()
                 addToRoles(userRole)
             }
             userService.save(user)


### PR DESCRIPTION
There was a problem when assigning the username and the password to a new user from the Google callback, this fix allows to login with Google Accounts.